### PR TITLE
Add GIMP plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The plugin will find the parent group layer, and re-outline the text layer.
 With this plugin, there is a common workflow with some repeated actions and keystrokes:
 - Create a new text layer with some text; or, modify an existing text layer (change the text, move the layer, etc.)
 - Press `X` to swap the foreground and background colors so that your outline color is now the foreground color
-- Press `Cmd/Ctrl + F`` to run the plugin
+- Press `Cmd/Ctrl + F` to run the plugin
 - Press `X` again to swap back to the font color
 - Create a new text layer with different text
 - Press `X` to swap back to the stroke color

--- a/README.md
+++ b/README.md
@@ -1,0 +1,77 @@
+
+# GIMP Text Outline Plugin
+
+## Description
+
+This GIMP plugin outlines text using the active brush, and allows the result
+to be more easily managed managed and re-outlined via a Layer Group.
+
+## Prior Work
+
+- [Pete Nu](https://pete.nu)
+- [CJ Kucera](https://github.com/apocalpytech)
+
+The history of this plugin began with Pete Nu's [original plugin](http://pete.nu/software/gimp-outline/), which was then [modified](https://github.com/apocalyptech/gimp-text-outline) by CJ Kucera.
+
+## Rationale
+
+I wanted to be able to re-outline text easily. More specifically, the existing plugins:
+  - Weren't quite working as expected if the text layer was inside of a Layer Group.
+  - Didn't have a good workflow to re-outline the text after you changed it.
+  - Didn't have the best way to manage the extra layers it created (e.g., a Layer Group).
+
+I also just wanted to try my hand at writing a GIMP plugin, even though the GIMP team is no longer interested in maintaining the Python-fu system.
+
+
+## Installation
+
+### Method 1: Copy the file to your GIMP plugins directory
+Copy the `managed-text-outline.py` file to your GIMP plugins directory.
+
+On Linux, this is usually `~/.config/GIMP/[version]/plug-ins/`
+On macOS, this is usually `~/Library/Application Support/GIMP/[version]/plug-ins/`
+On Windows, this is usually `C:\Users\<username>\AppData\Roaming\GIMP\[version]\plug-ins\`
+
+_Above, be sure to replace `[version]` with the version of GIMP you are using._
+
+### Method 2: Add the directory to your GIMP plugin search path
+
+You could also just add the directory you have the plugin in to your GIMP plugin search path.
+This can be done from the GIMP Preferences dialog, under Folders > Plug-Ins.
+
+## Usage
+
+- Make sure the brush settings are the ones you want for outlining the layer
+- Select a text layer that you want to outline
+- Run the plugin from Filters > Decore > Managed Text Outline
+- The plugin will create a new Layer Group with the original text layer and the outlined layer
+
+### Adjustments
+
+When you want to change the text in some way—the content of the text, the font, the position, etc.—you can do so by making your changes, and then simply running the plugin again.
+
+You can rerun the plugin on any of the 3 layers:
+- The parent group layer
+- The text layer
+- The outline layer
+
+The plugin will find the parent group layer, and re-outline the text layer.
+
+### Moving the Text
+- When the Move Tool mode is "Pick a Layer or Guide", GIMP can get a bit frustrating.
+- You aren't able to select the group layer, so you'll end up moving either the text layer or the outline layer.
+- Focus on moving the text layer to where you want to go. Then, simply rerun the plugin again, and it will recreate
+  the outline layer in the correct place.
+
+### Duplicating a Managed Layer Group
+If you duplicate a Managed Layer Group, there is a small side effect to be aware of.
+
+The plugin stores a reference to the parent group ID on each of the child layers—the text layer and the outline layer.
+
+When you duplicate a Managed Layer Group, the child layers still reference the original parent group ID. This means that if you try to run the plugin on the duplicated child layers, you will get an error about a mismatched parent group ID.
+
+If this happens, just select the parent group layer and run the filter, it will work.
+
+Furthermore, doing so will repair the references on the child layers so you can use them again as before.
+
+

--- a/README.md
+++ b/README.md
@@ -3,33 +3,23 @@
 
 ## Description
 
-This GIMP plugin outlines text using the active brush, and allows the result
+This GIMP plugin outlines a Text Layer using the active Brush, and allows the result
 to be more easily managed managed and re-outlined via a Layer Group.
-
-## Prior Work
-
-- [Pete Nu](https://pete.nu)
-- [CJ Kucera](https://github.com/apocalpytech)
-
-The history of this plugin began with Pete Nu's [original plugin](http://pete.nu/software/gimp-outline/), which was then [modified](https://github.com/apocalyptech/gimp-text-outline) by CJ Kucera.
-
-## Rationale
-
-I wanted to be able to re-outline text easily. More specifically, the existing plugins:
-  - Weren't quite working as expected if the text layer was inside of a Layer Group.
-  - Didn't have a good workflow to re-outline the text after you changed it.
-  - Required me to manually create a Layer Group and move the text and outline layers into it.
-
-I also just wanted to try my hand at writing a GIMP plugin, even though the GIMP team is no longer interested in maintaining the Python-fu system.
-
 
 ## Installation
 
+Installing Python-based GIMP plugins is pretty simple. This is especially true for plugins like this one where it is just a single file.
+
+In short, all you need to do is let GIMP know about the location of the Python file, and it will load it for you.
+
+You can do this in one of two ways.
+
 ### Method 1: Copy the file to your GIMP plugins directory
+
 Copy the `managed-text-outline.py` file to your GIMP plugins directory.
 
 - On Linux, this is usually `~/.config/GIMP/[version]/plug-ins/`
-- On macOS, this is usually `~/Library/Application Support/GIMP/[version]/plug-ins/`
+- On macOS, this is usually `~/Library/Application\ Support/GIMP/[version]/plug-ins/`
 - On Windows, this is usually `C:\Users\<username>\AppData\Roaming\GIMP\[version]\plug-ins\`
 
 _Above, be sure to replace `[version]` with the version of GIMP you are using._
@@ -38,54 +28,75 @@ _Above, be sure to replace `[version]` with the version of GIMP you are using._
 
 Alternatively, you can clone this repository to a directory of your choosing, and then instruct GIMP to search that directory for plugins.
 
+For example, you might want to make a directory like `$HOME/GIMP/[version]/plug-ins` to make them easier to manage.
+
 This can be done from the GIMP Preferences dialog, under Folders > Plug-Ins.
 
 ## Usage
-- Create a new text layer and enter some text, or select an existing text layer
-- Change the foreground color to the color you want for the outline
-- Select a brush that you want to use for the stroke of the outline
-- Run the plugin from Filters > Decore > Managed Text Outline
-- The plugin will create a new Layer Group containing the original text layer and the outlined layer
+- Create a new Text Layer and enter some text.
+- Change the Foreground Color to the Color you want for the outline.
+- Select a Brush that you want to use for the Stroke of the outline.
+- Run the plugin from Filters > Decore > Managed Text Outline.
+- The plugin will create a new Layer Group containing the original Text Layer and an Outline Layer beneath it.
 
 ### Adjustments
 
 When you want to change the text in some way—the content of the text, the font, the position, etc.—you can do so by making your changes, and then simply running the plugin again.
 
-You can rerun the plugin on any of the 3 layers:
-- The parent group layer
-- The text layer
-- The outline layer
+You can rerun the plugin on any of the 3 Layers:
+- The parent Group Layer
+- The child Text Layer
+- The child Outline Layer
 
-The plugin will find the parent group layer, and re-outline the text layer.
+Based on the active Layer you selected, the plugin will find the parent Group Layer, erase the old Outline Layer, and then create a new Outline Layer based on the current state of the Text Layer.
 
 #### Workflow
 
 With this plugin, there is a common workflow with some repeated actions and keystrokes:
-- Create a new text layer with some text; or, modify an existing text layer (change the text, move the layer, etc.)
-- Press `X` to swap the foreground and background colors so that your outline color is now the foreground color
-- Press `Cmd/Ctrl + F` to run the plugin
-- Press `X` again to swap back to the font color
-- Create a new text layer with different text
-- Press `X` to swap back to the stroke color
+- Create a new Text Layer with some text.
+- Alternatively, modify an existing Text Layer (change the text, reposition the layer, etc.).
+- Press `X` to swap the Foreground and Background Colors so that your outline Color is now the Foreground Color.
+- Press `Cmd/Ctrl + F` to run the plugin.
+- Press `X` again to swap back to the Font Color.
+- Create another new Text Layer with some content.
+- Press `X` to swap back to the Stroke Color.
 - Press `Cmd/Ctrl + F` to run the plugin
 
 ### Moving the Text
+
 When the Move Tool's mode is set to "Pick a Layer or Guide", GIMP can get a bit frustrating.
 
+Specifically, you aren't able to click on the parent Group Layer to select it because it has no content. Instead, you'll end up selecting either the Text Layer or the Outline layer (or something else).
 
-Specifically, you aren't able to click on the parent Group Layer to select it. Instead, you'll end up selecting either the text layer or the outline layer (or something underneath).
+Instead, focus on moving the Text Layer to where you want it to be. Then, simply rerun the plugin again, and it will recreate the Outline Layer in the correct place.
 
-Instead, focus on moving the text layer to where you want it to be. Then, simply rerun the plugin again, and it will recreate the outline layer in the correct place.
+Alternatively, just ensure the Move Tool mode is set to "Move the Active Layer" when working with these layers. You can also hold down the Shift key while using the Move Tool to toggle Tool Modes.
 
 ### Duplicating a Managed Layer Group
+
 If you duplicate a Managed Layer Group, there is a small side effect to be aware of.
 
-The plugin stores a reference to the parent group ID on each of the child layers—the text layer and the outline layer.
+The plugin stores a reference to the parent Group Layer ID on each of the child Layers—the Text Layer and the Outline Layer.
 
-When you duplicate a Managed Layer Group, the child layers still reference the original parent group ID. This means that if you try to run the plugin on the duplicated child layers, you will get an error about a mismatched parent group ID.
+When you duplicate a Managed Layer Group, the child Layers will still reference the original Managed Layer Group ID. This means that if you try to run the plugin on the duplicated child Layers, you will receive an error message: `ChildLayerDoesNotMatchRoot`.
 
-If this happens, just select the parent group layer and run the filter, it will work.
+If this happens, just select the current Managed Group Layer and run the filter, and the filter will apply as expected.
 
 Furthermore, doing so will repair the references on the child layers so you can use them again as before.
 
+## Rationale
 
+I wanted to be able to outline text, make changes to it, and then re-outline it easily.
+More specifically, the existing plugins:
+  - Weren't quite working as expected if the text layer was inside of a Layer Group.
+  - Didn't have the best workflow to re-outline the text after you changed it.
+  - Required me to manually create a Layer Group and move the text and outline layers into it.
+
+I also just wanted to try my hand at writing a Python-based GIMP plugin, even though the GIMP team is no longer interested in maintaining the Python-fu system.
+
+## Prior Work
+
+- [Pete Nu](https://pete.nu)
+- [CJ Kucera](https://github.com/apocalpytech)
+
+The history of this plugin began with Pete Nu's [original plugin](http://pete.nu/software/gimp-outline/), which was then [modified](https://github.com/apocalyptech/gimp-text-outline) by CJ Kucera.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The history of this plugin began with Pete Nu's [original plugin](http://pete.nu
 I wanted to be able to re-outline text easily. More specifically, the existing plugins:
   - Weren't quite working as expected if the text layer was inside of a Layer Group.
   - Didn't have a good workflow to re-outline the text after you changed it.
-  - Didn't have the best way to manage the extra layers it created (e.g., a Layer Group).
+  - Required me to manually create a Layer Group and move the text and outline layers into it.
 
 I also just wanted to try my hand at writing a GIMP plugin, even though the GIMP team is no longer interested in maintaining the Python-fu system.
 
@@ -28,23 +28,24 @@ I also just wanted to try my hand at writing a GIMP plugin, even though the GIMP
 ### Method 1: Copy the file to your GIMP plugins directory
 Copy the `managed-text-outline.py` file to your GIMP plugins directory.
 
-On Linux, this is usually `~/.config/GIMP/[version]/plug-ins/`
-On macOS, this is usually `~/Library/Application Support/GIMP/[version]/plug-ins/`
-On Windows, this is usually `C:\Users\<username>\AppData\Roaming\GIMP\[version]\plug-ins\`
+- On Linux, this is usually `~/.config/GIMP/[version]/plug-ins/`
+- On macOS, this is usually `~/Library/Application Support/GIMP/[version]/plug-ins/`
+- On Windows, this is usually `C:\Users\<username>\AppData\Roaming\GIMP\[version]\plug-ins\`
 
 _Above, be sure to replace `[version]` with the version of GIMP you are using._
 
 ### Method 2: Add the directory to your GIMP plugin search path
 
-You could also just add the directory you have the plugin in to your GIMP plugin search path.
+Alternatively, you can clone this repository to a directory of your choosing, and then instruct GIMP to search that directory for plugins.
+
 This can be done from the GIMP Preferences dialog, under Folders > Plug-Ins.
 
 ## Usage
-
-- Make sure the brush settings are the ones you want for outlining the layer
-- Select a text layer that you want to outline
+- Create a new text layer and enter some text, or select an existing text layer
+- Change the foreground color to the color you want for the outline
+- Select a brush that you want to use for the stroke of the outline
 - Run the plugin from Filters > Decore > Managed Text Outline
-- The plugin will create a new Layer Group with the original text layer and the outlined layer
+- The plugin will create a new Layer Group containing the original text layer and the outlined layer
 
 ### Adjustments
 
@@ -57,11 +58,24 @@ You can rerun the plugin on any of the 3 layers:
 
 The plugin will find the parent group layer, and re-outline the text layer.
 
+#### Workflow
+
+With this plugin, there is a common workflow with some repeated actions and keystrokes:
+- Create a new text layer with some text; or, modify an existing text layer (change the text, move the layer, etc.)
+- Press `X` to swap the foreground and background colors so that your outline color is now the foreground color
+- Press `Cmd/Ctrl + F`` to run the plugin
+- Press `X` again to swap back to the font color
+- Create a new text layer with different text
+- Press `X` to swap back to the stroke color
+- Press `Cmd/Ctrl + F` to run the plugin
+
 ### Moving the Text
-- When the Move Tool mode is "Pick a Layer or Guide", GIMP can get a bit frustrating.
-- You aren't able to select the group layer, so you'll end up moving either the text layer or the outline layer.
-- Focus on moving the text layer to where you want to go. Then, simply rerun the plugin again, and it will recreate
-  the outline layer in the correct place.
+When the Move Tool's mode is set to "Pick a Layer or Guide", GIMP can get a bit frustrating.
+
+
+Specifically, you aren't able to click on the parent Group Layer to select it. Instead, you'll end up selecting either the text layer or the outline layer (or something underneath).
+
+Instead, focus on moving the text layer to where you want it to be. Then, simply rerun the plugin again, and it will recreate the outline layer in the correct place.
 
 ### Duplicating a Managed Layer Group
 If you duplicate a Managed Layer Group, there is a small side effect to be aware of.

--- a/managed-text-outline.py
+++ b/managed-text-outline.py
@@ -221,9 +221,9 @@ def update_managed_group(image, root_layer, text_layer, existing_outline_layer=N
     return {
         "success": True,
         "data": {
-            "outline": outline_layer,
-            "group": root_layer,
-            "cloned": text_layer,
+            "root_layer": root_layer,
+            "text_layer": text_layer,
+            "outline_layer": outline_layer,
         },
     }
 
@@ -276,9 +276,9 @@ def convert_new_text_layer(image, original_text_layer):
     pdb.gimp_image_insert_layer(image, outline_layer, root_layer, 1)
 
     return {
-        "cloned": text_layer,
-        "group": root_layer,
-        "outline": outline_layer,
+        "root_layer": root_layer,
+        "text_layer": text_layer,
+        "outline_layer": outline_layer,
     }
 
 
@@ -360,20 +360,7 @@ def prepare_target_layer(image, original_layer):
 
         return update_managed_group(image, root_layer, text_layer, outline_layer)
 
-    # Add a new layer
-    result = convert_new_text_layer(image, original_layer)
-    outline = result["outline"]
-    group = result["group"]
-    cloned = result["cloned"]
-
-    return {
-        "success": True,
-        "data": {
-            "outline": outline,
-            "group": group,
-            "cloned": cloned,
-        },
-    }
+    return convert_new_text_layer(image, original_layer)
 
 
 def manage_text_outline(image, original_layer):
@@ -387,15 +374,13 @@ def manage_text_outline(image, original_layer):
     outcome = prepare_target_layer(image, original_layer)
     if not outcome["success"]:
         error = outcome["error"]
-        if error == "UnknownLayerType" or error == "FoundRootWithoutText":
-            return
-        else:
+        if error != "UnknownLayerType" and error != "FoundRootWithoutText":
             raise ValueError("Unknown error: %s" % error)
 
-    data = outcome["data"]
+        return
 
-    text_layer = data["cloned"]
-    outline_layer = data["outline"]
+    text_layer = outcome["data"]["text_layer"]
+    outline_layer = outcome["data"]["outline_layer"]
 
     gimp.progress_update(25)
 

--- a/managed-text-outline.py
+++ b/managed-text-outline.py
@@ -566,9 +566,9 @@ def entrypoint(image, original_layer):
     if Result.is_err(outcome):
         error = Result.get_error(outcome)
         if error != Errors.UnknownLayerType and error != Errors.FoundRootWithoutText:
-            raise ValueError("Unknown error: %s" % error)
+            raise ValueError("UnexpectedError: {}".format(error))
 
-        # Any other layers are a no-op.
+        # If we received an expected error, this just becomes a no-op.
         return
 
     target_layer_data = Result.get_data(outcome)

--- a/managed-text-outline.py
+++ b/managed-text-outline.py
@@ -474,7 +474,7 @@ def handle_existing_text(image, root_layer, text_layer, existing_outline_layer=N
         return outcome
 
     # Place the outline layer as the second child (index 1) of the root layer
-    pdb.gimp_image_insert_layer(image, outline_layer, root_layer, 1)
+    pdb.gimp_image_insert_layer(image, outline_layer, root_layer, position + 1)
 
     return Result.ok(
         {

--- a/managed-text-outline.py
+++ b/managed-text-outline.py
@@ -9,17 +9,19 @@ from gimpfu import *
 
 
 class ParasiteFields:
-    # Used to identify the root layer (group layer)
+    """Enum-like class for the specific parasite fields we use"""
+
     RootField = "managed-outline:root"
+    """Used to identify the root layer (group layer)"""
 
-    # Used to identify the text layer
     TextField = "managed-outline:text"
+    """Used to identify the text layer"""
 
-    # Used to identify the outline layer
     OutlineField = "managed-outline:outline"
+    """Used to identify the outline layer"""
 
-    # Used on the child layers to reference the layer ID of the root layer (group layer)
     RootReferenceField = "managed-outline:root-id"
+    """Used on the child layers to reference the layer ID of the root layer (group layer)"""
 
 
 class FFIUtils:

--- a/managed-text-outline.py
+++ b/managed-text-outline.py
@@ -107,12 +107,6 @@ class ManagedLayerUtils:
         return {"success": True, "data": parent}
 
 
-def get_text_layer_content(layer):
-    # TODO: This doesn't seem to work consistently
-    # It seems if the user doesn't make any adjustments from the default markup, it will be None
-    return pdb.gimp_text_layer_get_markup(layer)
-
-
 def get_root_id_ref(managed_layer):
     parasite = ParasiteUtils.get_parasite(managed_layer, PARASITE_ROOT_ID_REF)
     if parasite is None:

--- a/managed-text-outline.py
+++ b/managed-text-outline.py
@@ -398,7 +398,7 @@ def manage_text_outline(image, original_layer):
     gimp.progress_update(100)
 
 
-def run(image, layer):
+def run_plugin(image, layer):
     try:
         return manage_text_outline(image, layer)
     except Exception as e:
@@ -423,7 +423,7 @@ register(
     "*",
     [],
     [],
-    run,
+    run_plugin,
 )
 
 # Instruct GIMP to start the plugin.

--- a/managed-text-outline.py
+++ b/managed-text-outline.py
@@ -230,10 +230,17 @@ def update_managed_group(image, root_layer, text_layer, existing_outline_layer=N
 
 def convert_new_text_layer(image, original_text_layer):
     """
-    Adds a new layer beneath the given layer.  Return value is the new
-    layer.  Will raise an ValueError if for some reason we can't find
-    our own layer.  Note that after adding to the Gimp image, this
-    new layer will become the active layer.
+    Converts the given text layer into a managed text layer. Returns
+    a dictionary with the following keys:
+        - root_layer: The root layer (group layer)
+        - text_layer: The original text layer, cloned and converted to a managed text layer.
+        - outline_layer: The outline layer
+
+    Note that this function deletes the original text layer in order to move it underneath
+    the root layer.
+
+    This function is adapted to handle nested layers. It will either search the root of the
+    layers hierarchy (via the image) or the parent of provided original text layer.
     """
 
     # Get the layer position.
@@ -293,19 +300,19 @@ def outline_path(image, layer, path):
 
 def crop_layer(image, layer):
     """
-    Autocrops the given layer to be as small as possible using the existing `pdb` method.
+    Autocrops the given layer to be as small as possible using builtin autocrop functionality.
     """
     pdb.plug_in_autocrop_layer(image, layer)
 
 
 def determine_target_layer_type(layer):
     """
-    Determines the target layer type. This could be:
-    - managed-root (the parent Layer Group)
-    - managed-text (the text layer)
-    - managed-outline (the outline layer)
-    - text (a regular text layer for us to manage)
-    - unknown-type (something else we don't care about)
+    Determines the target layer type. Possible values:
+        - managed-root (the parent Layer Group)
+        - managed-text (the text layer)
+        - managed-outline (the outline layer)
+        - text (a regular text layer for us to manage)
+        - unknown-type (something else we don't care about)
     """
 
     if ManagedLayerUtils.is_managed_root(layer):
@@ -365,8 +372,9 @@ def prepare_target_layer(image, original_layer):
 
 def manage_text_outline(image, original_layer):
     """
-    Main function to do our processing.  image and layer are
-    passed in by default, we require no other arguments.
+    The main entrypoint to the plugin for outlining text and managing the result.
+
+    GIMP will provide us with the current image and the active layer.
     """
 
     gimp.progress_init("Drawing outline around text")

--- a/managed-text-outline.py
+++ b/managed-text-outline.py
@@ -1,48 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-# This GIMP plugin outlines text using the active brush, and allows the result
-# to be managed and re-outlined via a Managed Layer Group.
+# This GIMP plugin outlines text using the active brush, and allows the result to be managed and re-outlined via a Managed Layer Group.
 #
-# This plugin is based on a similar plugin by CJ Kucera, available at:
-#     https://github.com/apocalyptech/gimp-text-outline
-#
-# CJ's plugin is based on the plugin written by Pete Nu, available at:
-#     http://pete.nu/software/gimp-outline/
-#
-# I created this version because I wanted to be able to re-outline text easily. More specifically, the existing plugin:
-#   - Wasn't quite working as expected if the text layer was inside of a Layer Group.
-#   - Didn't have a good workflow to re-outline the text after you changed it.
-#   - Didn't have the best way to manage the extra layers it created (e.g., a Layer Group).
-#
-# I also just wanted to try my hand at writing a GIMP plugin, even though the GIMP team is no longer interested
-# in maintaining the Python-fu system.
-#
-#
-# INSTRUCTIONS
-# - Make sure the brush settings are the ones you want for outlining the layer
-# - Select a text layer that you want to outline
-# - Run the plugin from Filters > Decore > Text Outline
-# - The plugin will create a new layer group with the original text layer and the outlined layer
-#
-# - If you want to re-outline the text, just run the plugin again on any of the 3 layers (parent group layer, text layer,
-#   or the outline layer).
-#   - The plugin will then find the parent group layer and re-outline the text layer.
-#
-#
-# MOVING LAYERS
-# - When the Move Tool mode is "Pick a Layer or Guide", GIMP can get a bit frustrating.
-# - You aren't able to select the group layer, so you'll end up moving either the text layer or the outline layer.
-# - Focus on moving the text layer to where you want to go. Then, simply rerun the plugin again, and it will recreate
-#   the outline layer in the correct place.
-#
-#
-# DUPLICATING LAYERS
-# - If you duplicate a layer, the child text layers will still be referencing the original group layer's ID.
-# - If you apply the filter to the duplicated child layer (text or outline), you will get an error about a mismatched root ID
-# - If this happens, just select the parent group layer and run the filter, it will work.
-#
-
+# For more info, see the [README](https://github.com/ryanbaer/gimp-managed-text-outline/blob/master/README.md)
 
 from gimpfu import *
 

--- a/managed-text-outline.py
+++ b/managed-text-outline.py
@@ -116,7 +116,7 @@ class ManagedLayerUtils:
         if ManagedLayerUtils.is_managed_root(managed_layer):
             return {"success": True, "data": managed_layer}
 
-        outcome = get_root_id_ref(managed_layer)
+        outcome = ManagedLayerUtils.get_root_id_ref(managed_layer)
         if not outcome["success"]:
             return outcome
 
@@ -137,18 +137,18 @@ class ManagedLayerUtils:
 
         return {"success": True, "data": parent}
 
+    @staticmethod
+    def get_root_id_ref(root_layer):
+        """
+        Gets the root ID reference for the given root layer. Assumes the layer is
+        already a root layer.
+        """
 
-def get_root_id_ref(root_layer):
-    """
-    Gets the root ID reference for the given root layer. Assumes the layer is
-    already a root layer.
-    """
+        parasite = ParasiteUtils.get_parasite(root_layer, PARASITE_ROOT_ID_REF)
+        if parasite is None:
+            return {"success": False, "error": "Could not find root ID reference"}
 
-    parasite = ParasiteUtils.get_parasite(root_layer, PARASITE_ROOT_ID_REF)
-    if parasite is None:
-        return {"success": False, "error": "Could not find root ID reference"}
-
-    return {"success": True, "data": ParasiteUtils.get_parasite_data(parasite)}
+        return {"success": True, "data": ParasiteUtils.get_parasite_data(parasite)}
 
 
 class ParasiteUtils:

--- a/managed-text-outline.py
+++ b/managed-text-outline.py
@@ -16,7 +16,7 @@ PARASITE_OUTLINE = "managed-outline:outline"
 PARASITE_ROOT_ID_REF = "managed-outline:root-id"
 
 
-class CUtils:
+class FFIUtils:
     @staticmethod
     def c_style_boolean(value):
         """
@@ -47,7 +47,7 @@ class LayerUtils:
         it to a Python boolean via our helper method `CUtils.c_style_boolean`.
         """
 
-        return CUtils.c_style_boolean(pdb.gimp_item_is_text_layer(layer))
+        return FFIUtils.c_style_boolean(pdb.gimp_item_is_text_layer(layer))
 
 
 class ManagedLayerUtils:
@@ -185,7 +185,7 @@ class ParasiteUtils:
         not exist, returns None.
         """
 
-        return CUtils.remove_data_terminator(parasite.data)
+        return FFIUtils.remove_data_terminator(parasite.data)
 
 
 def text_to_path(image, text_layer):

--- a/managed-text-outline.py
+++ b/managed-text-outline.py
@@ -220,6 +220,8 @@ def update_managed_group(image, root_layer, text_layer, existing_outline_layer=N
     outline_layer = gimp.Layer(
         image, outline_title, image.width, image.height, RGBA_IMAGE, 100, NORMAL_MODE
     )
+
+    # Mark the new outline layer as managed and add a reference to the root layer
     ParasiteUtils.add_parasite(outline_layer, ParasiteFields.OutlineField, "True")
     ParasiteUtils.add_parasite(
         outline_layer, ParasiteFields.RootReferenceField, str(root_layer.ID)
@@ -302,9 +304,12 @@ def convert_new_text_layer(image, original_text_layer):
     pdb.gimp_image_insert_layer(image, outline_layer, root_layer, 1)
 
     return {
-        "root_layer": root_layer,
-        "text_layer": text_layer,
-        "outline_layer": outline_layer,
+        "success": True,
+        "data": {
+            "root_layer": root_layer,
+            "text_layer": text_layer,
+            "outline_layer": outline_layer,
+        },
     }
 
 

--- a/managed-text-outline.py
+++ b/managed-text-outline.py
@@ -8,22 +8,6 @@
 from gimpfu import *
 
 
-class ParasiteFields:
-    """Enum-like class for the specific parasite fields we use"""
-
-    RootField = "managed-outline:root"
-    """Used to identify the root layer (group layer)"""
-
-    TextField = "managed-outline:text"
-    """Used to identify the text layer"""
-
-    OutlineField = "managed-outline:outline"
-    """Used to identify the outline layer"""
-
-    RootReferenceField = "managed-outline:root-id"
-    """Used on the child layers to reference the layer ID of the root layer (group layer)"""
-
-
 class FFIUtils:
     @staticmethod
     def c_style_boolean(value):
@@ -36,217 +20,352 @@ class FFIUtils:
     @staticmethod
     def remove_data_terminator(s):
         """
-        Removes the data terminator from a parasite's data. This is done by removing the
-        null byte from the end of the string. This is necessary because the data is stored
-        as a C-style string, which is null-terminated.
+        Remove the null byte ("\x00") from the end of the given string. This is necessary because GIMP
+        stores Parasite data as a C-style string, which is null-terminated, and doesn't seem to clean
+        it for us before returning it.
         """
 
         return s.replace("\x00", "")
 
 
-class LayerUtils:
+class Result:
     @staticmethod
-    def is_text_layer(layer):
+    def ok(data):
         """
-        Determines if the given layer is a text layer.
-        This is done by using GIMP's `gimp_item_is_text_layer` method from it's procedural database.
-
-        Because it is via their internal FFI, it returns a C-style boolean (0 or 1), so we convert
-        it to a Python boolean via our helper method `CUtils.c_style_boolean`.
+        Accepts a data value of any type.
+        Returns an OK Result with the given data.
         """
 
-        return FFIUtils.c_style_boolean(pdb.gimp_item_is_text_layer(layer))
-
-
-class ManagedLayerUtils:
-    @staticmethod
-    def is_managed_root(layer):
-        """
-        Determines if the given layer is a managed root layer. This is done by checking for the
-        presence of the `ParasiteFields.RootField` parasite.
-        """
-
-        return layer.parasite_find(ParasiteFields.RootField) is not None
+        return {"success": True, "data": data}
 
     @staticmethod
-    def is_managed_text(layer):
+    def err(error):
         """
-        Determines if the given layer is a managed text layer. This is done by checking for the
-        presence of the `ParasiteFields.TextField` parasite.
+        Accepts a str error message.
+        Returns an Error Result with the given error message.
         """
 
-        return layer.parasite_find(ParasiteFields.TextField) is not None
+        return {"success": False, "error": error}
 
     @staticmethod
-    def is_managed_outline(layer):
-        """
-        Determines if the given layer is a managed outline layer. This is done by checking for the
-        presence of the `ParasiteFields.OutlineField` parasite.
-        """
-
-        return layer.parasite_find(ParasiteFields.OutlineField) is not None
+    def is_ok(result):
+        return result["success"] is True
 
     @staticmethod
-    def does_group_match(root_layer, child_layer):
-        if len(root_layer.children) == 0:
-            return {
-                "success": False,
-                "error": "Expected group layer to have at least one child, but it does not",
-            }
-
-        if not ManagedLayerUtils.is_managed_root(root_layer):
-            return {
-                "success": False,
-                "error": "Expected group layer to be a managed group, but it is not",
-            }
-
-        child_layer_parasite = ParasiteUtils.get_parasite(
-            child_layer, ParasiteFields.RootReferenceField
-        )
-        if child_layer_parasite is None:
-            return {
-                "success": False,
-                "error": "Expected target layer to have a root ID reference, but it does not",
-            }
-
-        group_id = str(root_layer.ID)
-        ref_group_id = ParasiteUtils.get_parasite_data(child_layer_parasite)
-
-        return {"success": True, "data": group_id == ref_group_id}
+    def is_err(result):
+        return result["success"] is False
 
     @staticmethod
-    def get_root(image, managed_layer):
+    def get_data(result):
         """
-        Gets the root layer for the given managed layer. If the managed layer is already a root
-        layer, it will return itself. If it is not a managed layer, its result will have a success value of False.
+        Returns the data from the given Result. If the Result is an error, raises a ValueError.
+        This should never be called on a value that is not a Result or a Result that is an error,
+        so it is valid to raise an error here.
         """
 
-        if ManagedLayerUtils.is_managed_root(managed_layer):
-            return {"success": True, "data": managed_layer}
-
-        outcome = ManagedLayerUtils.get_parent_root_id(managed_layer)
-        if not outcome["success"]:
-            return outcome
-
-        root_id = outcome["data"]
-
-        parent = managed_layer.parent
-        if parent is None:
-            return {"success": False, "error": "Layer has no parent"}
-
-        if not ManagedLayerUtils.is_managed_root(parent):
-            return {"success": False, "error": "Parent layer is not a managed root"}
-
-        if str(parent.ID) != root_id:
-            return {
-                "success": False,
-                "error": "Root ID reference does not match parent ID",
-            }
-
-        return {"success": True, "data": parent}
+        if Result.is_ok(result):
+            return result["data"]
+        else:
+            raise ValueError("Result is not ok")
 
     @staticmethod
-    def get_parent_root_id(child_layer):
+    def get_error(result):
         """
-        Gets the root ID reference for the given child layer.
+        Returns the error from the given Result. If the Result is not an error, raises a ValueError.
+        This should never be called on a value that is not a Result or a Result that is not an error,
+        so it is valid to raise an error here.
         """
 
-        parasite = ParasiteUtils.get_parasite(
-            child_layer, ParasiteFields.RootReferenceField
-        )
-        if parasite is None:
-            return {"success": False, "error": "Could not find root ID reference"}
-
-        return {"success": True, "data": ParasiteUtils.get_parasite_data(parasite)}
+        if Result.is_err(result):
+            return result["error"]
+        else:
+            raise ValueError("Result is not an error")
 
 
-class ParasiteUtils:
+class Errors:
+    UnexpectedTargetLayerType = "UnexpectedTargetLayerType"
+    ExpectedTextLayer = "ExpectedTextLayer"
+    UnknownLayerType = "UnknownLayerType"
+
+    ParentlessChild = "ParentlessChild"
+    ChildlessRoot = "ChildlessRoot"
+    FoundRootWithoutText = "FoundRootWithoutText"
+    LayerWasNotManagedRoot = "LayerWasNotManagedRoot"
+    ParentLayerWasNotManagedRoot = "ParentLayerWasNotManagedRoot"
+
+    ChildLayerWithoutRootReference = "ChildLayerWithoutRootReference"
+    ChildLayerDoesNotMatchRoot = "ChildLayerDoesNotMatchRoot"
+    TextLayerDoesNotMatchRoot = "TextLayerDoesNotMatchRoot"
+    OutlineLayerDoesNotMatchRoot = "OutlineLayerDoesNotMatchRoot"
+
+    ParasiteDataMustBeString = "ParasiteDataMustBeString"
+
+
+class ParasiteSupport:
+    class Fields:
+        """Enum-like class for the specific Parasite fields we use"""
+
+        Root = "managed-outline:root"
+        """Used to identify the Root Layer (Group Layer)"""
+
+        Text = "managed-outline:text"
+        """Used to identify the Text Layer"""
+
+        Outline = "managed-outline:outline"
+        """Used to identify the Outline Layer"""
+
+        RootReference = "managed-outline:root-id"
+        """Used on the Child Layers to reference the Layer ID of the Root Layer"""
+
     @staticmethod
     def add_parasite(layer, key, value):
         """
-        Adds a parasite to the given layer.  If the parasite already
+        Adds a Parasite to the given Layer. If the Parasite already
         exists, it will be replaced. If the value passed in is not
         a string, it raises a ValueError.
 
-        The created parasite is persistent and undoable.
+        The created Parasite is persistent and undoable.
         """
 
         if type(value) is not str:
-            raise ValueError("Expected value to be a string")
+            return Result.err(Errors.ParasiteDataMustBeString)
 
-        return layer.attach_new_parasite(
+        parasite = layer.attach_new_parasite(
             key, PARASITE_PERSISTENT | PARASITE_UNDOABLE, value
         )
+
+        return Result.ok(parasite)
 
     @staticmethod
     def get_parasite(layer, key):
         """
-        Gets the parasite with the given key from the given layer.
-        Returns None if the parasite does not exist.
+        Gets the Parasite with the given key from the given Layer.
+        Returns None if the Parasite does not exist.
         """
 
         return layer.parasite_find(key)
 
     @staticmethod
-    def get_parasite_data(parasite):
+    def get_data(parasite):
         """
-        Gets the data from the given parasite.  If the parasite does
+        Gets the data from the given Parasite. If the Parasite does
         not exist, returns None.
         """
 
+        if parasite is None:
+            return None
+
         return FFIUtils.remove_data_terminator(parasite.data)
+
+    @staticmethod
+    def has_field(layer, field):
+        """
+        Returns a bool that indicates whether the given Layer has a Parasite with the given field.
+        """
+
+        return layer.parasite_find(field) is not None
+
+
+class LayerSupport:
+    @staticmethod
+    def get_outline_layer_name(text_layer):
+        return "Outline: {}".format(text_layer.name)
+
+    @staticmethod
+    def is_plain_text_layer(layer):
+        """
+        Determines if the given Layer is a Text Layer.
+        This is done by using GIMP's `gimp_item_is_text_layer` method from it's procedural database.
+
+        Because this is done via GIMP's internal FFI, it returns a C-style boolean (0 or 1),
+        so we convert it to a Python boolean via our helper method `CUtils.c_style_boolean`.
+        """
+
+        return FFIUtils.c_style_boolean(pdb.gimp_item_is_text_layer(layer))
+
+    @staticmethod
+    def has_field(layer, field):
+        """
+        Determines if the given Layer has a Parasite with the provided field.
+        """
+
+        return ParasiteSupport.has_field(layer, field)
+
+    @staticmethod
+    def is_managed_root(layer):
+        """
+        Determines if the provided Layer is a Managed Root Layer. This is done by checking for the
+        presence of the `ParasiteSupport.Fields.RootField` Parasite.
+        """
+
+        return LayerSupport.has_field(layer, ParasiteSupport.Fields.Root)
+
+    @staticmethod
+    def is_managed_text(layer):
+        """
+        Determines if the provided Layer is a Managed Text Layer. This is done by checking for the
+        presence of the `ParasiteSupport.Fields.TextField` Parasite.
+        """
+        return LayerSupport.has_field(layer, ParasiteSupport.Fields.Text)
+
+    @staticmethod
+    def is_managed_outline(layer):
+        """
+        Determines if the provided Layer is a Managed Outline Layer. This is done by checking for the
+        presence of the `ParasiteSupport.Fields.OutlineField` Parasite.
+        """
+
+        return LayerSupport.has_field(layer, ParasiteSupport.Fields.Outline)
+
+    @staticmethod
+    def get_parent_root_id(child_layer):
+        """
+        Gets the Root ID reference for the given Child Layer.
+        """
+
+        parasite = ParasiteSupport.get_parasite(
+            child_layer, ParasiteSupport.Fields.RootReference
+        )
+        if parasite is None:
+            return Result.err(Errors.ChildLayerWithoutRootReference)
+
+        return Result.ok(ParasiteSupport.get_data(parasite))
+
+    @staticmethod
+    def does_group_match(root_layer, child_layer):
+        """
+        Determines if the given Child Layer is a child of the given Root Layer.
+        Returns a Result containing a bool indicating this condition.
+        """
+
+        if len(root_layer.children) == 0:
+            return Result.err(Errors.ChildlessRoot)
+
+        if not LayerSupport.is_managed_root(root_layer):
+            return Result.err(Errors.LayerWasNotManagedRoot)
+
+        child_layer_parasite = ParasiteSupport.get_parasite(
+            child_layer, ParasiteSupport.Fields.RootReference
+        )
+        if child_layer_parasite is None:
+            return Result.err(Errors.ChildLayerWithoutRootReference)
+
+        group_id = str(root_layer.ID)
+        ref_group_id = ParasiteSupport.get_data(child_layer_parasite)
+
+        return Result.ok(group_id == ref_group_id)
+
+    @staticmethod
+    def get_root(image, managed_layer):
+        """
+        Returns a Result containing the Root Layer for a Managed Layer.
+
+        If the received Layer is the Root Layer, it returns itself.
+        If the received Layer is not a Managed Layer, the Result contains an error.
+        """
+
+        if LayerSupport.is_managed_root(managed_layer):
+            return Result.ok(managed_layer)
+
+        outcome = LayerSupport.get_parent_root_id(managed_layer)
+        if Result.is_err(outcome):
+            return outcome
+
+        root_id = Result.get_data(outcome)
+
+        parent = managed_layer.parent
+        if parent is None:
+            return Result.err(Errors.ParentlessChild)
+
+        if not LayerSupport.is_managed_root(parent):
+            return Result.err(Errors.ParentLayerWasNotManagedRoot)
+
+        if str(parent.ID) != root_id:
+            return Result.err(Errors.ChildLayerDoesNotMatchRoot)
+
+        return Result.ok(parent)
 
 
 def text_to_path(image, text_layer):
     """
-    Creates a new path based on the passed-in text layer.  Will end
-    up throwing a RuntimeException if our layer is not text.  Returns
-    the new path.
+    Accepts the Image and a Text Layer.
+    Returns a Result containing a new Path based on the Text Layer.
+    If Layer is not a Text Layer, returns an error result.
+
+    Note: A Managed Text Layer is a subset of a Plain Text Layer, so both types validate
+    as a Plain Text Layer.
     """
+
+    if not LayerSupport.is_plain_text_layer(text_layer):
+        return Result.err(Errors.ExpectedTextLayer)
 
     path = pdb.gimp_vectors_new_from_text_layer(image, text_layer)
     pdb.gimp_image_insert_vectors(image, path, None, 0)
-    return path
+
+    return Result.ok(path)
 
 
-def update_managed_group(image, root_layer, text_layer, existing_outline_layer=None):
+def handle_existing_group(image, root_layer, text_layer, existing_outline_layer=None):
+    """
+    Re-outlines the Text Layer for an existing Managed Group.
+
+    If provided, the `existing_outline_layer` will be deleted, and a new one will be
+    created in its place.
+
+    Returns a Result containing a dictionary with the following keys:
+        - root_layer: The Root Layer (Group Layer)
+        - text_layer: The existing Managed Text Layer, untouched.
+        - outline_layer: The newly created Outline Layer
+    """
+
     position = root_layer.children.index(text_layer)
 
     if existing_outline_layer:
         pdb.gimp_image_remove_layer(image, existing_outline_layer)
 
     # Add a new layer below the selected one
-    outline_title = "%s Text Outline" % (text_layer.name)
+    outline_title = LayerSupport.get_outline_layer_name(text_layer)
     outline_layer = gimp.Layer(
         image, outline_title, image.width, image.height, RGBA_IMAGE, 100, NORMAL_MODE
     )
 
     # Mark the new outline layer as managed and add a reference to the root layer
-    ParasiteUtils.add_parasite(outline_layer, ParasiteFields.OutlineField, "True")
-    ParasiteUtils.add_parasite(
-        outline_layer, ParasiteFields.RootReferenceField, str(root_layer.ID)
+    outcome = ParasiteSupport.add_parasite(
+        outline_layer, ParasiteSupport.Fields.Outline, "True"
     )
+    if Result.is_err(outcome):
+        return outcome
+
+    outcome = ParasiteSupport.add_parasite(
+        outline_layer, ParasiteSupport.Fields.RootReference, str(root_layer.ID)
+    )
+    if Result.is_err(outcome):
+        return outcome
 
     # This handles the duplicated root group issue. We essentially reparent the text layer
     # to the valid managed root layer it is now underneath.
-    ParasiteUtils.add_parasite(
-        text_layer, ParasiteFields.RootReferenceField, str(root_layer.ID)
+    outcome = ParasiteSupport.add_parasite(
+        text_layer, ParasiteSupport.Fields.RootReference, str(root_layer.ID)
     )
+    if Result.is_err(outcome):
+        return outcome
 
+    # Place the outline layer as the second child (index 1) of the root layer
     pdb.gimp_image_insert_layer(image, outline_layer, root_layer, 1)
 
-    return {
-        "success": True,
-        "data": {
+    return Result.ok(
+        {
             "root_layer": root_layer,
             "text_layer": text_layer,
             "outline_layer": outline_layer,
-        },
-    }
+        }
+    )
 
 
-def convert_new_text_layer(image, original_text_layer):
+def handle_new_text_layer(image, original_text_layer):
     """
+    original_text_layer will be deleted by this function.
+
     Converts the given text layer into a managed text layer. Returns
     a dictionary with the following keys:
         - root_layer: The root layer (group layer)
@@ -269,8 +388,13 @@ def convert_new_text_layer(image, original_text_layer):
         position = original_text_layer.parent.children.index(original_text_layer)
 
     root_layer = pdb.gimp_layer_group_new(image)
-    root_layer.name = "Outlined " + original_text_layer.name
-    ParasiteUtils.add_parasite(root_layer, ParasiteFields.RootField, "True")
+    root_layer.name = "Group: {}".format(original_text_layer.name)
+
+    outcome = ParasiteSupport.add_parasite(
+        root_layer, ParasiteSupport.Fields.Root, "True"
+    )
+    if Result.is_err(outcome):
+        return outcome
 
     if is_nested:
         pdb.gimp_image_insert_layer(
@@ -286,154 +410,195 @@ def convert_new_text_layer(image, original_text_layer):
     pdb.gimp_image_remove_layer(image, original_text_layer)
     text_layer.name = layer_name
 
-    ParasiteUtils.add_parasite(text_layer, ParasiteFields.TextField, "True")
-    ParasiteUtils.add_parasite(
-        text_layer, ParasiteFields.RootReferenceField, str(root_layer.ID)
+    outcome = ParasiteSupport.add_parasite(
+        text_layer, ParasiteSupport.Fields.Text, "True"
     )
+    if Result.is_err(outcome):
+        return outcome
 
-    # Add a new layer below the selected one
-    outline_title = "%s Text Outline" % (layer_name)
+    outcome = ParasiteSupport.add_parasite(
+        text_layer, ParasiteSupport.Fields.RootReference, str(root_layer.ID)
+    )
+    if Result.is_err(outcome):
+        return outcome
+
+    # Add the Outline Layer below the Text Layer
+    outline_title = LayerSupport.get_outline_layer_name(text_layer)
     outline_layer = gimp.Layer(
         image, outline_title, image.width, image.height, RGBA_IMAGE, 100, NORMAL_MODE
     )
-    ParasiteUtils.add_parasite(outline_layer, ParasiteFields.OutlineField, "True")
-    ParasiteUtils.add_parasite(
-        outline_layer, ParasiteFields.RootReferenceField, str(root_layer.ID)
+    outcome = ParasiteSupport.add_parasite(
+        outline_layer, ParasiteSupport.Fields.Outline, "True"
     )
+    if Result.is_err(outcome):
+        return outcome
+
+    outcome = ParasiteSupport.add_parasite(
+        outline_layer, ParasiteSupport.Fields.RootReference, str(root_layer.ID)
+    )
+    if Result.is_err(outcome):
+        return outcome
 
     pdb.gimp_image_insert_layer(image, outline_layer, root_layer, 1)
 
-    return {
-        "success": True,
-        "data": {
+    return Result.ok(
+        {
             "root_layer": root_layer,
             "text_layer": text_layer,
             "outline_layer": outline_layer,
-        },
-    }
+        }
+    )
 
 
 def outline_path(image, layer, path):
     """
-    Outline the path with the current brush, and then remove it.
+    Outline the Path with the current Brush, and then remove the Path.
     """
 
     pdb.gimp_edit_stroke_vectors(layer, path)
     pdb.gimp_image_remove_vectors(image, path)
 
 
-def crop_layer(image, layer):
-    """
-    Autocrops the given layer to be as small as possible using builtin autocrop functionality.
-    """
-    pdb.plug_in_autocrop_layer(image, layer)
-
-
 def determine_target_layer_type(layer):
     """
-    Determines the target layer type. Possible values:
-        - managed-root (the parent Layer Group)
-        - managed-text (the text layer)
-        - managed-outline (the outline layer)
-        - text (a regular text layer for us to manage)
-        - unknown-type (something else we don't care about)
+    Determines the target Layer type and returns a Result.
+
+    Possible values:
+        - "managed-root": the parent Group Layer
+        - "managed-text": the child Text Layer
+        - "managed-outline": the child Outline Layer
+        - "text": a new plain Text Layer that will be converted to a managed layer
+        - "unknown-type": some other type of Layer we're not interested in
     """
 
-    if ManagedLayerUtils.is_managed_root(layer):
-        return {"success": True, "data": "managed-root"}
-    elif ManagedLayerUtils.is_managed_outline(layer):
-        return {"success": True, "data": "managed-outline"}
-    elif ManagedLayerUtils.is_managed_text(layer):
-        return {"success": True, "data": "managed-text"}
-    elif LayerUtils.is_text_layer(layer):
-        return {"success": True, "data": "text"}
+    if LayerSupport.is_managed_root(layer):
+        return Result.ok("managed-root")
+    elif LayerSupport.is_managed_outline(layer):
+        return Result.ok("managed-outline")
+    elif LayerSupport.is_managed_text(layer):
+        return Result.ok("managed-text")
+    elif LayerSupport.is_plain_text_layer(layer):
+        return Result.ok("text")
     else:
-        return {"success": True, "data": "unknown-type"}
+        return Result.ok("unknown-type")
 
 
 def prepare_target_layer(image, original_layer):
-    outcome = determine_target_layer_type(original_layer)
-    if not outcome["success"]:
-        raise ValueError(outcome["error"])
+    """
+    Prepares a Text Layer to be outlined. Works for both unoutlined and already outlined Text Layers.
 
-    target_layer_type = outcome["data"]
+    Returns a Result containing a dictionary
+    containing the following keys:
+        - root_layer: The Root Layer (Group Layer)
+        - text_layer: The Text Layer
+        - outline_layer: The Outline Layer
+
+    This function is able to handle both scenarios:
+        - An existing Managed Outline Layer (Group, Text, or Outline)
+        - A new Text Layer that hasn't yet been outlined.
+
+    This is the function that allows the user to select any of the three Managed Layers and
+    still get the desired outcome.
+    """
+
+    outcome = determine_target_layer_type(original_layer)
+    if Result.is_err(outcome):
+        return outcome
+
+    target_layer_type = Result.get_data(outcome)
+
+    if target_layer_type == "text":
+        return handle_new_text_layer(image, original_layer)
 
     if target_layer_type == "unknown-type":
-        return {"success": False, "error": "UnknownLayerType"}
+        return Result.err(Errors.UnknownLayerType)
 
     if (
-        target_layer_type == "managed-root"
-        or target_layer_type == "managed-text"
-        or target_layer_type == "managed-outline"
+        (target_layer_type != "managed-root")
+        and (target_layer_type != "managed-text")
+        and (target_layer_type != "managed-outline")
     ):
-        outcome = ManagedLayerUtils.get_root(image, original_layer)
-        if not outcome["success"]:
-            return outcome
+        return Result.err(Errors.UnexpectedTargetLayerType)
 
-        root_layer = outcome["data"]
-        text_layer = None
-        outline_layer = None
-        for child_layer in root_layer.children:
-            if ManagedLayerUtils.is_managed_text(child_layer):
-                text_layer = child_layer
-            elif ManagedLayerUtils.is_managed_outline(child_layer):
-                outline_layer = child_layer
+    # At this point we know we have a Managed Layer.
+    outcome = LayerSupport.get_root(image, original_layer)
+    if Result.is_err(outcome):
+        return outcome
 
-        if not text_layer:
-            return {"success": False, "error": "FoundRootWithoutText"}
+    root_layer = Result.get_data(outcome)
+    text_layer = None
+    outline_layer = None
 
-        if not ManagedLayerUtils.does_group_match(root_layer, text_layer):
-            return {"success": False, "error": "TextLayerDoesNotMatchRoot"}
+    for child_layer in root_layer.children:
+        if LayerSupport.is_managed_text(child_layer):
+            text_layer = child_layer
+        elif LayerSupport.is_managed_outline(child_layer):
+            outline_layer = child_layer
 
-        if outline_layer:
-            if not ManagedLayerUtils.does_group_match(root_layer, outline_layer):
-                return {"success": False, "error": "OutlineLayerDoesNotMatchRoot"}
+    if not text_layer:
+        return Result.err(Errors.FoundRootWithoutText)
 
-        return update_managed_group(image, root_layer, text_layer, outline_layer)
+    if not LayerSupport.does_group_match(root_layer, text_layer):
+        return Result.err(Errors.TextLayerDoesNotMatchRoot)
 
-    return convert_new_text_layer(image, original_layer)
+    if outline_layer:
+        # TODO: do we really need to check this?
+        if not LayerSupport.does_group_match(root_layer, outline_layer):
+            return Result.err(Errors.OutlineLayerDoesNotMatchRoot)
+
+    return handle_existing_group(image, root_layer, text_layer, outline_layer)
 
 
-def manage_text_outline(image, original_layer):
+def entrypoint(image, original_layer):
     """
-    The main entrypoint to the plugin for outlining text and managing the result.
+    The main entrypoint to the plugin for outlining Text Layers and managing the Outlined Layers
+    as changes are made.
 
-    GIMP will provide us with the current image and the active layer.
+    GIMP will provide us with the current Image and the active Layer.
     """
 
     gimp.progress_init("Drawing outline around text")
 
     outcome = prepare_target_layer(image, original_layer)
-    if not outcome["success"]:
-        error = outcome["error"]
-        if error != "UnknownLayerType" and error != "FoundRootWithoutText":
+    if Result.is_err(outcome):
+        error = Result.get_error(outcome)
+        if error != Errors.UnknownLayerType and error != Errors.FoundRootWithoutText:
             raise ValueError("Unknown error: %s" % error)
 
+        # Any other layers are a no-op.
         return
 
-    text_layer = outcome["data"]["text_layer"]
-    outline_layer = outcome["data"]["outline_layer"]
+    target_layer_data = Result.get_data(outcome)
+
+    text_layer = target_layer_data["text_layer"]
+    outline_layer = target_layer_data["outline_layer"]
 
     gimp.progress_update(25)
 
     # Convert the text layer to a path that we can stroke (outline)
-    path = text_to_path(image, text_layer)
+    path_outcome = text_to_path(image, text_layer)
+    if Result.is_err(path_outcome):
+        raise ValueError(Result.get_error(path_outcome))
+
+    path = Result.get_data(path_outcome)
     gimp.progress_update(50)
 
     # Outline the path of the text layer and remove the path we made
     outline_path(image, outline_layer, path)
     gimp.progress_update(75)
 
-    # The outline layer is as big as the image so the stroke wouldn't get
-    # clipped. Now we need to crop it down to the size of the text layer.
-    crop_layer(image, outline_layer)
+    # We originally created the Outline Layer as big as the entire Image.
+    # This prevented the Stroke from being clipped by the Layer bounds of the Text Layer.
+    # Now, we can crop it to its minimal size, close to the size of the Text Layer.
+    pdb.plug_in_autocrop_layer(image, outline_layer)
     gimp.progress_update(100)
 
 
 def run_plugin(image, layer):
     try:
-        return manage_text_outline(image, layer)
+        return entrypoint(image, layer)
     except Exception as e:
+        gimp.progress_update(100)
         import traceback
 
         gimp.message(str(e))
@@ -447,7 +612,14 @@ def run_plugin(image, layer):
 register(
     "managed_text_outline",
     "Managed Text Outline",
-    "Outlines text layers with the active brush. Creates a new 'managed' Layer Group with the original text layer and the outlined layer.",
+    """
+Outlines Text Layers with the active Brush.
+
+This plugin creates a new "Managed" Layer Group containing your Text Layer and an Outline Layer underneath it.
+This keeps the 2 Layers organized under a single Group Layer.
+
+It then allows you to easily re-outline the Text Layer by simply re-running the plugin after editing it.
+    """,
     "Ryan Baer",
     "© 2024 Ryan Baer",
     "January 2024",

--- a/managed-text-outline.py
+++ b/managed-text-outline.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# This GIMP plugin outlines text using the active brush, and allows the result
+# to be managed and re-outlined via a Managed Layer Group.
+#
+# This plugin is based on a similar plugin by CJ Kucera, available at:
+#     https://github.com/apocalyptech/gimp-text-outline
+#
+# CJ's plugin is based on the plugin written by Pete Nu, available at:
+#     http://pete.nu/software/gimp-outline/
+#
+# I created this version because I wanted to be able to re-outline text easily. More specifically, the existing plugin:
+#   - Wasn't quite working as expected if the text layer was inside of a Layer Group.
+#   - Didn't have a good workflow to re-outline the text after you changed it.
+#   - Didn't have the best way to manage the extra layers it created (e.g., a Layer Group).
+#
+# I also just wanted to try my hand at writing a GIMP plugin, even though the GIMP team is no longer interested
+# in maintaining the Python-fu system.
+#
+#
+# INSTRUCTIONS
+# - Make sure the brush settings are the ones you want for outlining the layer
+# - Select a text layer that you want to outline
+# - Run the plugin from Filters > Decore > Text Outline
+# - The plugin will create a new layer group with the original text layer and the outlined layer
+#
+# - If you want to re-outline the text, just run the plugin again on any of the 3 layers (parent group layer, text layer,
+#   or the outline layer).
+#   - The plugin will then find the parent group layer and re-outline the text layer.
+#
+#
+# MOVING LAYERS
+# - When the Move Tool mode is "Pick a Layer or Guide", GIMP can get a bit frustrating.
+# - You aren't able to select the group layer, so you'll end up moving either the text layer or the outline layer.
+# - Focus on moving the text layer to where you want to go. Then, simply rerun the plugin again, and it will recreate
+#   the outline layer in the correct place.
+#
+#
+# DUPLICATING LAYERS
+# - If you duplicate a layer, the child text layers will still be referencing the original group layer's ID.
+# - If you apply the filter to the duplicated child layer (text or outline), you will get an error about a mismatched root ID
+# - If this happens, just select the parent group layer and run the filter, it will work.
+#
+
+
+from gimpfu import *
+
+PARASITE_ROOT_KEY = "managed-outline:root"
+
+PARASITE_TEXT = "managed-outline:text"
+PARASITE_OUTLINE = "managed-outline:outline"
+
+# Used on other nodes to reference the layer ID of the root node (group layer)
+PARASITE_ROOT_ID_REF = "managed-outline:root-id"
+
+
+class CUtils:
+    @staticmethod
+    def c_style_boolean(value):
+        return True if value == 1 else False
+
+    @staticmethod
+    def remove_data_terminator(s):
+        return s.replace("\x00", "")
+
+
+class LayerUtils:
+    @staticmethod
+    def is_text_layer(layer):
+        return CUtils.c_style_boolean(pdb.gimp_item_is_text_layer(layer))
+
+
+class ManagedLayerUtils:
+    @staticmethod
+    def is_managed_root(layer):
+        return layer.parasite_find(PARASITE_ROOT_KEY) is not None
+
+    @staticmethod
+    def is_managed_text(layer):
+        return layer.parasite_find(PARASITE_TEXT) is not None
+
+    @staticmethod
+    def is_managed_outline(layer):
+        return layer.parasite_find(PARASITE_OUTLINE) is not None
+
+    @staticmethod
+    def does_group_match(root_layer, child_layer):
+        if len(root_layer.children) == 0:
+            return {
+                "success": False,
+                "error": "Expected group layer to have at least one child, but it does not",
+            }
+
+        if not ManagedLayerUtils.is_managed_root(root_layer):
+            return {
+                "success": False,
+                "error": "Expected group layer to be a managed group, but it is not",
+            }
+
+        child_layer_parasite = ParasiteUtils.get_parasite(
+            child_layer, PARASITE_ROOT_ID_REF
+        )
+        if child_layer_parasite is None:
+            return {
+                "success": False,
+                "error": "Expected target layer to have a root ID reference, but it does not",
+            }
+
+        group_id = str(root_layer.ID)
+        ref_group_id = ParasiteUtils.get_parasite_data(child_layer_parasite)
+
+        # ref_group_id = CUtils.remove_x00(child_layer_parasite.data)
+
+        return {"success": True, "data": group_id == ref_group_id}
+
+    @staticmethod
+    def get_root(image, managed_layer):
+        """
+        Gets the root layer for the given managed layer. If the managed layer is already a root
+        layer, it will return itself. If it is not a managed layer, its result will have a success value of False.
+        """
+
+        if ManagedLayerUtils.is_managed_root(managed_layer):
+            return {"success": True, "data": managed_layer}
+
+        outcome = get_root_id_ref(managed_layer)
+        if not outcome["success"]:
+            return outcome
+
+        root_id = outcome["data"]
+
+        parent = managed_layer.parent
+        if parent is None:
+            return {"success": False, "error": "Layer has no parent"}
+
+        if not ManagedLayerUtils.is_managed_root(parent):
+            return {"success": False, "error": "Parent layer is not a managed root"}
+
+        if str(parent.ID) != root_id:
+            return {
+                "success": False,
+                "error": "Root ID reference does not match parent ID",
+            }
+
+        return {"success": True, "data": parent}
+
+
+def get_text_layer_content(layer):
+    # TODO: This doesn't seem to work consistently
+    # It seems if the user doesn't make any adjustments from the default markup, it will be None
+    return pdb.gimp_text_layer_get_markup(layer)
+
+
+def get_root_id_ref(managed_layer):
+    parasite = ParasiteUtils.get_parasite(managed_layer, PARASITE_ROOT_ID_REF)
+    if parasite is None:
+        return {"success": False, "error": "Could not find root ID reference"}
+
+    return {"success": True, "data": ParasiteUtils.get_parasite_data(parasite)}
+
+
+class ParasiteUtils:
+    @staticmethod
+    def add_parasite(layer, key, value):
+        if type(value) is not str:
+            raise ValueError("Expected value to be a string")
+
+        return layer.attach_new_parasite(
+            key, PARASITE_PERSISTENT | PARASITE_UNDOABLE, value
+        )
+
+    @staticmethod
+    def get_parasite(layer, key):
+        return layer.parasite_find(key)
+
+    @staticmethod
+    def get_parasite_data(parasite):
+        return CUtils.remove_data_terminator(parasite.data)
+
+
+def text_to_path(image, layer):
+    """
+    Creates a new path based on the passed-in text layer.  Will end
+    up throwing a RuntimeException if our layer is not text.  Returns
+    the new path.
+    """
+
+    path = pdb.gimp_vectors_new_from_text_layer(image, layer)
+    pdb.gimp_image_insert_vectors(image, path, None, 0)
+    return path
+
+
+def update_managed_group(image, root_layer, text_layer, existing_outline_layer=None):
+    position = root_layer.children.index(text_layer)
+
+    # clone = pdb.gimp_layer_copy(text_layer, True)
+
+    if existing_outline_layer:
+        pdb.gimp_image_remove_layer(image, existing_outline_layer)
+
+    # Add a new layer below the selected one
+    outline_title = "%s Text Outline" % (text_layer.name)
+    outline_layer = gimp.Layer(
+        image, outline_title, image.width, image.height, RGBA_IMAGE, 100, NORMAL_MODE
+    )
+    ParasiteUtils.add_parasite(outline_layer, PARASITE_OUTLINE, "True")
+    ParasiteUtils.add_parasite(outline_layer, PARASITE_ROOT_ID_REF, str(root_layer.ID))
+
+    ParasiteUtils.add_parasite(text_layer, PARASITE_ROOT_ID_REF, str(root_layer.ID))
+
+    pdb.gimp_image_insert_layer(image, outline_layer, root_layer, 1)
+
+    return {
+        "success": True,
+        "data": {
+            "outline": outline_layer,
+            "group": root_layer,
+            "cloned": text_layer,
+        },
+    }
+
+
+def convert_new_text_layer(image, original_text_layer):
+    """
+    Adds a new layer beneath the given layer.  Return value is the new
+    layer.  Will raise an ValueError if for some reason we can't find
+    our own layer.  Note that after adding to the Gimp image, this
+    new layer will become the active layer.
+    """
+
+    # Get the layer position.
+    if original_text_layer.parent is None:
+        is_nested = False
+        position = image.layers.index(original_text_layer)
+    else:
+        is_nested = True
+        position = original_text_layer.parent.children.index(original_text_layer)
+
+    root_layer = pdb.gimp_layer_group_new(image)
+    root_layer.name = "Outlined " + original_text_layer.name
+    ParasiteUtils.add_parasite(root_layer, PARASITE_ROOT_KEY, "True")
+
+    if is_nested:
+        pdb.gimp_image_insert_layer(
+            image, root_layer, original_text_layer.parent, position
+        )
+    else:
+        image.add_layer(root_layer, position)
+
+    layer_name = original_text_layer.name
+    text_layer = pdb.gimp_layer_copy(original_text_layer, True)
+
+    pdb.gimp_image_insert_layer(image, text_layer, root_layer, 0)
+    pdb.gimp_image_remove_layer(image, original_text_layer)
+    text_layer.name = layer_name
+
+    ParasiteUtils.add_parasite(text_layer, PARASITE_TEXT, "True")
+    ParasiteUtils.add_parasite(text_layer, PARASITE_ROOT_ID_REF, str(root_layer.ID))
+
+    # Add a new layer below the selected one
+    outline_title = "%s Text Outline" % (layer_name)
+    outline_layer = gimp.Layer(
+        image, outline_title, image.width, image.height, RGBA_IMAGE, 100, NORMAL_MODE
+    )
+    ParasiteUtils.add_parasite(outline_layer, PARASITE_OUTLINE, "True")
+    ParasiteUtils.add_parasite(outline_layer, PARASITE_ROOT_ID_REF, str(root_layer.ID))
+
+    pdb.gimp_image_insert_layer(image, outline_layer, root_layer, 1)
+
+    return {
+        "cloned": text_layer,
+        "group": root_layer,
+        "outline": outline_layer,
+    }
+
+
+def stroke_path_and_remove(image, layer, path):
+    """
+    Strokes along the given path, using the current active brush.
+    Then removes our temporary path from the list
+    """
+
+    pdb.gimp_edit_stroke_vectors(layer, path)
+    pdb.gimp_image_remove_vectors(image, path)
+
+
+def crop_layer(image, layer):
+    """
+    Autocrops the given layer to be as small as possible.  This actually
+    just calls a different plugin which does all the heavy lifting.
+    """
+    pdb.plug_in_autocrop_layer(image, layer)
+
+
+def determine_target_layer_type(layer):
+    """
+    Determines whether the layer is a text layer, a manage root layer, a managed text layer, or a managed outline layer.
+    """
+
+    if ManagedLayerUtils.is_managed_root(layer):
+        return {"success": True, "data": "managed-root"}
+    elif ManagedLayerUtils.is_managed_outline(layer):
+        return {"success": True, "data": "managed-outline"}
+    elif ManagedLayerUtils.is_managed_text(layer):
+        return {"success": True, "data": "managed-text"}
+    elif LayerUtils.is_text_layer(layer):
+        return {"success": True, "data": "text"}
+    else:
+        return {"success": True, "data": "unknown-type"}
+
+
+def prepare_target_layer(image, original_layer):
+    outcome = determine_target_layer_type(original_layer)
+    if not outcome["success"]:
+        raise ValueError(outcome["error"])
+
+    target_layer_type = outcome["data"]
+
+    if target_layer_type == "unknown-type":
+        return {"success": False, "error": "UnknownLayerType"}
+
+    if (
+        target_layer_type == "managed-root"
+        or target_layer_type == "managed-text"
+        or target_layer_type == "managed-outline"
+    ):
+        outcome = ManagedLayerUtils.get_root(image, original_layer)
+        if not outcome["success"]:
+            return outcome
+
+        root_layer = outcome["data"]
+        text_layer = None
+        outline_layer = None
+        for child_layer in root_layer.children:
+            if ManagedLayerUtils.is_managed_text(child_layer):
+                text_layer = child_layer
+            elif ManagedLayerUtils.is_managed_outline(child_layer):
+                outline_layer = child_layer
+
+        if not text_layer:
+            return {"success": False, "error": "FoundRootWithoutText"}
+
+        if not ManagedLayerUtils.does_group_match(root_layer, text_layer):
+            return {"success": False, "error": "TextLayerDoesNotMatchRoot"}
+
+        if outline_layer:
+            if not ManagedLayerUtils.does_group_match(root_layer, outline_layer):
+                return {"success": False, "error": "OutlineLayerDoesNotMatchRoot"}
+
+        return update_managed_group(image, root_layer, text_layer, outline_layer)
+
+    # Add a new layer
+    result = convert_new_text_layer(image, original_layer)
+    outline = result["outline"]
+    group = result["group"]
+    cloned = result["cloned"]
+
+    return {
+        "success": True,
+        "data": {
+            "outline": outline,
+            "group": group,
+            "cloned": cloned,
+        },
+    }
+
+
+def manage_text_outline(image, original_layer):
+    """
+    Main function to do our processing.  image and layer are
+    passed in by default, we require no other arguments.
+    """
+
+    gimp.progress_init("Drawing outline around text")
+
+    outcome = prepare_target_layer(image, original_layer)
+    if not outcome["success"]:
+        error = outcome["error"]
+        if error == "UnknownLayerType" or error == "FoundRootWithoutText":
+            return
+        else:
+            raise ValueError("Unknown error: %s" % error)
+
+    data = outcome["data"]
+
+    text_layer = data["cloned"]
+    outline_layer = data["outline"]
+
+    gimp.progress_update(25)
+
+    # Create a path from the current layer
+    path = text_to_path(image, text_layer)
+    gimp.progress_update(50)
+
+    # Stroke along our path and remove it
+    stroke_path_and_remove(image, outline_layer, path)
+    gimp.progress_update(75)
+
+    # Now autocrop the layer so it doesn't take up the
+    # whole image size.  Relies on another plugin which
+    # I assume must be stock, since I didn't install it
+    # manually.
+    crop_layer(image, outline_layer)
+    gimp.progress_update(100)
+
+    # Aaaand exit.
+    return
+
+
+def run(image, layer):
+    try:
+        return manage_text_outline(image, layer)
+    except Exception as e:
+        import traceback
+
+        gimp.message(str(e))
+        print(e)
+        traceback.print_exc()
+
+
+# This is the plugin registration function
+register(
+    "managed_text_outline",
+    "Managed Text Outline",
+    "Outlines text layers with the active brush. Creates a new 'managed' Layer Group with the original text layer and the outlined layer.",
+    "Ryan Baer",
+    "© 2024 Ryan Baer",
+    "January 2024",
+    "<Image>/Filters/Decor/Managed Text Outline",
+    "*",
+    [],
+    [],
+    run,
+)
+
+main()


### PR DESCRIPTION
## Summary

This PR introduces a Python-based GIMP plugin for outlining text with manageable layer groups.

## Progress
<details>
<summary>Monday, January 22, 2024</summary>

Reviewed the PR and made several adjustments from the list below, as well as other improvements I found to make.

- I fully converted the code to using the `Result` pattern, with some static helper methods
- I added an Errors class, categorized every error into a standard message, and then made a `get_user_facing_message` utility to display useful messages to the end user when something goes wrong.
- I finished up documenting all of the code
- I tweaked the README and adjusted the layout to have a better focus on what people will want first (installation, usage before caring about my rationale).
- I renamed all of the `Utils` namespace classes to use the term `Support` instead
- I made a `ParasiteSupport` class as part of the above and simplified some methods in there
- Most bugs I came from how hard it is to refactor without a type system. There were a few times where I converted the return type to a `Result` but forgot to handle that on the callers.
</details>
<details>
<summary>Sunday, January 21, 2024</summary>
The plugin itself is relatively stable. The code is bit messy and should have a full pass now that everything's working.

- [x] Not everything is namespaced under the utils classes that could be.
- [x] Naming of certain concepts could be revisted
- [x] Replace some legacy structure—e.g., referring to the text layer as "cloned"
- [x] Be on the look out for any lingering bugs or edge cases
- [x] Add some more inline comments to document things a bit and generally just help to track the logic.
- [x] Document all the functions and methods.
- [x] Move global `PARASITE_` constants into a namespaced enum-like class.
   - There are already several `PARASITE_` values from GIMP in the same global scope, so this will help clean things up and prevent future collisions.
- [x] Consider removing the huge comment and just link to the README
- [x] Remove `get_text_layer_content` since we never really needed it to begin with
- Maybe reorganize and simplify the workflow a bit.
- Look for any other places where the `Result` pattern could be used (e.g., failures being returned directly rather than wrapped)
</details>
<details>
<summary>Saturday, January 20, 2023</summary>
- Decided to fork the existing plugin and started learning about the interface available from GIMP
- Adjusted the plugin to just create a Layer Group first, then added Layers to the Layer Group
- Came up with the plan below

### GIMP Text Outline Plguin Plan

- Rework so that the text and outline are stored in a Layer Group
- Use Parasites to attach data to existing Managed Layers
	- The Group itself will get 'managed-outline:root' -> 'True'
	- The Text Layer will use Parasites:
		- 'managed-outline:text' -> ~<the text content>~ 'True'
		- 'managed-outline:root-id' -> <the Parent Group ID>
	- The Outline Layer will get:
		- 'managed-outline:outline' -> 'True'
		- 'managed-outline:root-id' -> 'True'
	- Validate each Parasite Field
		- Text Layer
			- Still of type text. e.g., hasn't been rasterized
				- Root ID reference matches the Parent Group ID. e.g., hasn't been moved
		- Outline Layer
			- ~Root ID reference matches parent group ID~
			- Not necessary to validate, since we recreate the Outline Layer on each run to catch any changes
	- If anything is off with this, including that 'managed-outline:text' is no longer a Text Layer (rasterized), we will abort
	- However, if there is just no Outline Layer, skip the step of deleting the outline and just make a new one

- Validate that the selected Layer is a valid Layer
	- A new Text Layer (unmanaged)
	- A Managed Layer (Parent Group Layer, Text Layer, or Outline Layer)

- If it is a new Text Layer:
  - Proceed as usual. Outline the Text Layer and the two Child Layers in a new Parent Group Layer

- If it is the Parent Group Layer:
  - Find the Text Layer and optionally the Outline Layer in the Layer's children
  - Delete the old Outline Layer
  - Generate a new Vector Path from the Text Layer
  - Apply the outline as usual to generate the new Outline Layer
  - Insert the new Outline Layer inside of the Parent Group Layer

- If they've applied it to an existing Child Layer directly:
	- Bubble up to the Parent Group Layer from the Parasite data `managed-outline:root-id`
	- Proceed as usual
</details>